### PR TITLE
refactor: keep legacy client config type alongside dynamic config

### DIFF
--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -1,8 +1,13 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
+/// Legacy structured client config; kept for compatibility or reference.
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct ClientConfig {
+pub struct LegacyClientConfig {
     pub report_title: HashMap<String, String>,
 }
+
+/// Dynamic client-side configuration; shape is defined by YAML at runtime.
+pub type ClientConfig = Value;


### PR DESCRIPTION
不约定 client_config.yaml 的具体格式。只需要满足 yaml 格式即可。
